### PR TITLE
fix Listing visits

### DIFF
--- a/lib/Features/visits/Data/datasources/visit_datasources.dart
+++ b/lib/Features/visits/Data/datasources/visit_datasources.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:visit_tracker/Features/visits/Data/models/visit_model.dart';
+import 'package:visit_tracker/Features/visits/Domain/entities/visit.dart';
 import 'package:visit_tracker/core/constants/api_constants.dart';
 import 'package:visit_tracker/core/errors/failures.dart';
 import 'package:visit_tracker/core/network/api_client.dart';
@@ -48,7 +49,18 @@ class VisitRemoteDataSourceImpl implements VisitRemoteDataSource {
       
       final visits = data.map((json) {
         try {
-          return VisitModel.fromJson(json as Map<String, dynamic>);
+          // Use Visit.fromJson first, then convert to VisitModel
+          final visit = Visit.fromJson(json as Map<String, dynamic>);
+          return VisitModel(
+            id: visit.id,
+            customerId: visit.customerId,
+            visitDate: visit.visitDate,
+            status: visit.status,
+            location: visit.location,
+            notes: visit.notes,
+            activitiesDone: visit.activitiesDone,
+            createdAt: visit.createdAt,
+          );
         } catch (e) {
           print('❌ Error parsing visit: $e');
           print('🔍 Raw JSON: $json');


### PR DESCRIPTION
Modified the JSON parsing logic in VisitRemoteDataSourceImpl.getVisits() to use the existing robust null handling from the Visit entity instead of relying on the auto-generated VisitModel.fromJson() method.

Approach:

1. Parse JSON using Visit.fromJson() which has proven null-safe parsing logic
2. Convert the parsed Visit object to VisitModel using the constructor
3. Maintain type safety while leveraging existing null handling